### PR TITLE
JSDK-54 geotab.sdk library updated to last version (9.0.7)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>
-    <geotab.sdk.version>9.0.6</geotab.sdk.version>
+    <geotab.sdk.version>9.0.7</geotab.sdk.version>
   </properties>
 
   <repositories>


### PR DESCRIPTION
Updating of the geotab.sdk library to version 9.0.7